### PR TITLE
Improve dev wysteria database behaviour

### DIFF
--- a/server/database/bolt.go
+++ b/server/database/bolt.go
@@ -35,7 +35,7 @@ type boltDb struct {
 func (b *boltDb) createBuckets() error {
 	return b.db.Update(func(tx *bolt.Tx) error {
 		for _, bucket := range [][]byte{bucketCollection, bucketItem, bucketVersion, bucketResource, bucketLink, bucketCollisions} {
-			_, err := tx.CreateBucket(bucket)
+			_, err := tx.CreateBucketIfNotExists(bucket)
 			if err != nil {
 				return nil
 			}

--- a/server/searchbase/bleve.go
+++ b/server/searchbase/bleve.go
@@ -279,7 +279,8 @@ func genericQuery(limit, from int, index bleve.Index, convert func(desc *wyc.Que
 	var result *bleve.SearchResult
 	for _, query := range queries {
 		search_query := bleve.NewQueryStringQuery(convert(query))
-		search := bleve.NewSearchRequest(search_query)
+
+		search := bleve.NewSearchRequestOptions(search_query, limit, from, false)
 		res, err := index.Search(search)
 
 		if err != nil {
@@ -299,23 +300,7 @@ func genericQuery(limit, from int, index bleve.Index, convert func(desc *wyc.Que
 		ids = append(ids, doc.ID)
 	}
 
-	if limit < 1 {
-		// there is no limit, return them all
-		return ids, nil
-	}
-
-	if limit >= len(ids) {
-		// we found less results than our limit, return them all
-		return ids, nil
-	}
-
-	if limit+from >= len(ids) {
-		// we've been asked for the last segment of the values
-		return ids[from:], nil
-	}
-
-	// We've been asked for a page of results somewhere in the middle
-	return ids[from : limit+from], nil
+	return ids, nil
 }
 
 // Search for collections matching the given query descriptions


### PR DESCRIPTION
BoltDb will raise if the bucket already exists, so if you're busy dev-ing you have to keep removing the dev db. I've replaced this behavior with 'create bucket if not exists' .. so it is more convenient I think.

Bleve has an undocumented (as far as I could find, but their website's search button breaks with network err for me :P) way of setting limit / offset etc .. which is waaaay better than the previous approach.