### PR TITLE
Feature/instrumentation

### DIFF
--- a/server/config.go
+++ b/server/config.go
@@ -5,6 +5,7 @@ import (
 	common "github.com/voidshard/wysteria/common"
 	wcm "github.com/voidshard/wysteria/common/middleware"
 	wdb "github.com/voidshard/wysteria/server/database"
+	wsi "github.com/voidshard/wysteria/server/instrumentation"
 	wsb "github.com/voidshard/wysteria/server/searchbase"
 	"log"
 	"os"
@@ -14,9 +15,11 @@ import (
 var Config *configuration
 
 type configuration struct {
-	Database   wdb.Settings
-	Searchbase wsb.Settings
-	Middleware wcm.Settings
+	Database        wdb.Settings
+	Searchbase      wsb.Settings
+	Middleware      wcm.Settings
+	Health          wsi.WebserverConfig
+	Instrumentation map[string]*wsi.Settings
 }
 
 // Load the server side configuration from somewhere.
@@ -66,6 +69,19 @@ func makeDefaults() *configuration {
 		wcm.Settings{
 			Driver: wcm.DriverNats,
 			Config: "",
+		},
+
+		wsi.WebserverConfig{
+			Port:           8150,
+			EndpointHealth: "/health",
+		},
+
+		map[string]*wsi.Settings{
+			"default": &wsi.Settings{
+				Driver:   wsi.DriverLogfile,
+				Location: filepath.Join(os.TempDir(), "wysteria_logs"),
+				Target:   "out.log",
+			},
 		},
 	}
 }

--- a/server/instrumentation/elastic.go
+++ b/server/instrumentation/elastic.go
@@ -1,0 +1,68 @@
+package instrumentation
+
+import (
+	"gopkg.in/olivere/elastic.v2"
+	"errors"
+	"fmt"
+)
+
+// Write log document to Elastic
+//
+type elasticLogger struct {
+	url string
+	index string
+	client *elastic.Client
+}
+
+// Create a client to write data to elastic
+//
+func newElasticLogger(settings *Settings) (MonitorOutput, error) {
+	client, err := elastic.NewClient(
+		// Set elastic url to the given host / port
+		elastic.SetURL(settings.Location),
+
+		// If enabled there is some race condition in the underlying lib that can cause use to always
+		// attempt to connect to the localhost. Assuming you're not running ES on the localhost you'll be
+		// given a "no available hosts" error or something.
+		elastic.SetSniff(false),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	e := &elasticLogger{
+		url: settings.Location,
+		index: settings.Target,
+		client: client,
+	}
+	return e, e.createIndexIfNotExists(settings.Target)
+}
+
+// Checks if an index with the given name exists. If not, creates the index.
+func (l *elasticLogger) createIndexIfNotExists(index string) error {
+	exists, err := l.client.IndexExists(index).Do()
+	if err != nil {
+		return err
+	}
+	if exists {
+		return nil
+	}
+
+	createIndex, err := l.client.CreateIndex(index).Do()
+	if err != nil {
+		return err
+	}
+	if createIndex.Acknowledged {
+		return nil
+	}
+
+	return errors.New(fmt.Sprintf("Creation of index %s not acknowledged", index))
+}
+
+func (l *elasticLogger) Log(doc *event) {
+	l.client.Index().Index(l.index).Type(l.index).BodyJson(doc).Do()
+}
+
+func (l *elasticLogger) Close() {
+	l.client.Stop()
+}

--- a/server/instrumentation/elastic.go
+++ b/server/instrumentation/elastic.go
@@ -1,16 +1,34 @@
 package instrumentation
 
 import (
-	"gopkg.in/olivere/elastic.v2"
 	"errors"
 	"fmt"
+	"gopkg.in/olivere/elastic.v2"
 )
+
+const defaultMapping = `{
+	"mappings": {
+		"wysterialog": {
+			"properties": {
+				"EpochTime": {"type": "date", "format": "epoch_millis"},
+				"CallTarget": {"type": "string"},
+				"CallType": {"type": "string"},
+				"TimeTaken": {"type": "integer"},
+				"InFunc": {"type": "string"},
+				"Msg": {"type": "string"},
+				"Severity": {"type": "string"},
+				"Note": {"type": "string"},
+				"UTCTime": {"type": "string"}
+			}
+		}
+	}
+}`
 
 // Write log document to Elastic
 //
 type elasticLogger struct {
-	url string
-	index string
+	url    string
+	index  string
 	client *elastic.Client
 }
 
@@ -31,8 +49,8 @@ func newElasticLogger(settings *Settings) (MonitorOutput, error) {
 	}
 
 	e := &elasticLogger{
-		url: settings.Location,
-		index: settings.Target,
+		url:    settings.Location,
+		index:  settings.Target,
 		client: client,
 	}
 	return e, e.createIndexIfNotExists(settings.Target)
@@ -48,7 +66,7 @@ func (l *elasticLogger) createIndexIfNotExists(index string) error {
 		return nil
 	}
 
-	createIndex, err := l.client.CreateIndex(index).Do()
+	createIndex, err := l.client.CreateIndex(index).BodyString(defaultMapping).Do()
 	if err != nil {
 		return err
 	}

--- a/server/instrumentation/instrumentation.go
+++ b/server/instrumentation/instrumentation.go
@@ -1,0 +1,199 @@
+/*
+Instrumentation module
+ - collects server stats on calls made, errors.
+ - writes stats to various output(s).
+ - keeps the most recent handful of documents around for viewing.
+   That is, 'viewing' here refers to showing the most recent activity suitable for health checks via the HTTP
+   health route. More advanced graphing of calls / viewing / Monitoring is left to more suitable systems
+   (kibana, grafana .. etc) and isn't intended to be viewable directly via wysteria at any point.
+
+Simply put a Monitor stores 'stats' documents via some MonitorOutput(s), and keeps the last
+handful of documents handy for display via health checks.
+*/
+
+package instrumentation
+
+import (
+	"errors"
+	"fmt"
+	"time"
+)
+
+const (
+	// The driver names that we accept
+	DriverLogfile = "logfile"
+	DriverElastic  = "elastic"
+
+	// Call types
+	callFind = "find"
+	callCreate = "create"
+	callDelete = "delete"
+	callPublish = "publish"
+	callPublished = "published"
+	callUpdate = "update"
+
+	// What is being found / created / deleted / updated
+	targetCollection = "collection"
+	targetItem = "item"
+	targetVersion = "version"
+	targetResource = "resource"
+	targetLink = "link"
+)
+
+var (
+	// List of known drivers & the functions to start up a connection
+	connectors = map[string]func(*Settings) (MonitorOutput, error){
+		DriverLogfile: newFileLogger,
+		DriverElastic: newElasticLogger,
+	}
+)
+
+// Return a connect function for the given settings, or err if it can't be found
+//
+func Connect(settings *Settings) (MonitorOutput, error) {
+	connector, ok := connectors[settings.Driver]
+	if !ok {
+		return nil, errors.New(fmt.Sprintf("Connector not found for %s", settings.Driver))
+	}
+	return connector(settings)
+}
+
+type event struct {
+	Msg string
+	Note string
+	InFunc string
+	Severity string
+	EpochTime int64
+	UTCTime string
+	TimeTaken int64
+	CallType string
+	CallTarget string
+}
+
+type Opt func(*event)
+
+// Set InFunc value
+//
+func InFunc(msg string) Opt {
+	return func(i *event) {
+		i.InFunc = msg
+	}
+}
+
+// Record the kind of function call we're making
+//
+func IsFind() Opt {
+	return func(i *event) {
+		i.CallType = callFind
+	}
+}
+
+func IsCreate() Opt {
+	return func(i *event) {
+		i.CallType = callCreate
+	}
+}
+
+func IsDelete() Opt {
+	return func(i *event) {
+		i.CallType = callDelete
+	}
+}
+
+func IsUpdate() Opt {
+	return func(i *event) {
+		i.CallType = callUpdate
+	}
+}
+
+func IsPublish() Opt {
+	return func(i *event) {
+		i.CallType = callPublish
+	}
+}
+
+func IsPublished() Opt {
+	return func(i *event) {
+		i.CallType = callPublished
+	}
+}
+
+func TargetCollection() Opt {
+	return func(i *event) {
+		i.CallTarget = targetCollection
+	}
+}
+
+// Set what kind of obj we're targeting (trying to find, create, delete etc)
+//
+func TargetItem() Opt {
+	return func(i *event) {
+		i.CallTarget = targetItem
+	}
+}
+
+func TargetVersion() Opt {
+	return func(i *event) {
+		i.CallTarget = targetVersion
+	}
+}
+
+func TargetResource() Opt {
+	return func(i *event) {
+		i.CallTarget = targetResource
+	}
+}
+
+func TargetLink() Opt {
+	return func(i *event) {
+		i.CallTarget = targetLink
+	}
+}
+
+// Set InFunc value
+//
+func Time(t int64) Opt {
+	return func(i *event) {
+		i.TimeTaken = t
+	}
+}
+
+// Set Note value
+//
+func Note(msg string) Opt {
+	return func(i *event) {
+		i.Note = msg
+	}
+}
+
+// Represents somewhere to write stats / log documents to
+//
+type MonitorOutput interface {
+	Log(*event)
+	Close()
+}
+
+// Create a new event with some default fields filled out
+//
+func newEvent(msg string) *event {
+	tnow := time.Now()
+	return &event{
+		Msg: msg,
+		EpochTime: tnow.Unix(),
+		UTCTime: tnow.UTC().String(),
+		Severity: severityInfo,
+	}
+}
+
+// Settings for some form of logging output
+//
+type Settings struct {
+	// What will be used to write the log
+	Driver string
+
+	// What host / location the log should go to
+	Location string
+
+	// Where in the given location the log should go
+	Target string
+}

--- a/server/instrumentation/instrumentation.go
+++ b/server/instrumentation/instrumentation.go
@@ -22,22 +22,22 @@ import (
 const (
 	// The driver names that we accept
 	DriverLogfile = "logfile"
-	DriverElastic  = "elastic"
+	DriverElastic = "elastic"
 
 	// Call types
-	callFind = "find"
-	callCreate = "create"
-	callDelete = "delete"
-	callPublish = "publish"
+	callFind      = "find"
+	callCreate    = "create"
+	callDelete    = "delete"
+	callPublish   = "publish"
 	callPublished = "published"
-	callUpdate = "update"
+	callUpdate    = "update"
 
 	// What is being found / created / deleted / updated
 	targetCollection = "collection"
-	targetItem = "item"
-	targetVersion = "version"
-	targetResource = "resource"
-	targetLink = "link"
+	targetItem       = "item"
+	targetVersion    = "version"
+	targetResource   = "resource"
+	targetLink       = "link"
 )
 
 var (
@@ -59,14 +59,14 @@ func Connect(settings *Settings) (MonitorOutput, error) {
 }
 
 type event struct {
-	Msg string
-	Note string
-	InFunc string
-	Severity string
-	EpochTime int64
-	UTCTime string
-	TimeTaken int64
-	CallType string
+	Msg        string
+	Note       string
+	InFunc     string
+	Severity   string
+	EpochTime  int64
+	UTCTime    string
+	TimeTaken  int64
+	CallType   string
 	CallTarget string
 }
 
@@ -150,7 +150,7 @@ func TargetLink() Opt {
 	}
 }
 
-// Set InFunc value
+// Set Time (time taken in nano seconds) value
 //
 func Time(t int64) Opt {
 	return func(i *event) {
@@ -178,10 +178,10 @@ type MonitorOutput interface {
 func newEvent(msg string) *event {
 	tnow := time.Now()
 	return &event{
-		Msg: msg,
-		EpochTime: tnow.Unix(),
-		UTCTime: tnow.UTC().String(),
-		Severity: severityInfo,
+		Msg:       msg,
+		EpochTime: tnow.Unix() * 1000,
+		UTCTime:   tnow.UTC().String(),
+		Severity:  severityInfo,
 	}
 }
 

--- a/server/instrumentation/log.go
+++ b/server/instrumentation/log.go
@@ -1,0 +1,96 @@
+package instrumentation
+
+import (
+	"log"
+	"path/filepath"
+	"os"
+)
+
+const logdivider = "|"
+
+// The most trivial of implementations - write via vanilla log package.
+//
+type simpleLogger struct {
+	logger *log.Logger
+	filehandle *os.File
+}
+
+// Check if a dir exists. If not, create it with the given perms.
+//
+func ensureDirectory(path string, mode os.FileMode) error {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		// Create the dir
+		err = os.Mkdir(path, mode)
+		if err != nil {
+			return err
+		}
+
+		// Chmod to work around potential umask issues
+		return os.Chmod(path, mode)
+	}
+	return nil
+}
+
+// Open a file if it exists, possibly create it first.
+//
+func openFile(path string) (*os.File, error) {
+	var fh *os.File
+
+	_, err := os.Stat(path)
+	if os.IsNotExist(err) {
+		// Create the log file
+		tmp, err := os.Create(path)
+		if err != nil {
+			return nil, err
+		}
+		fh = tmp
+	} else {
+		tmp, err := os.OpenFile(path, os.O_RDWR | os.O_CREATE | os.O_APPEND, 0666)
+		if err != nil {
+			return nil, err
+		}
+		fh = tmp
+	}
+
+	return fh, nil
+}
+
+// Create a new simple logger given a log.Logger to write to
+//
+func newFileLogger(settings *Settings) (MonitorOutput, error) {
+	err := ensureDirectory(settings.Location, 0775)
+	if err != nil {
+		return nil, err
+	}
+
+	fh, err := openFile(filepath.Join(settings.Location, settings.Target))
+	if err != nil {
+		return nil, err
+	}
+
+	return &simpleLogger{
+		logger: log.New(fh, "", log.LstdFlags),
+		filehandle: fh,
+	}, nil
+}
+
+// Log event to file.
+//
+func (l *simpleLogger) Log(doc *event) {
+	l.logger.Println( logdivider,
+		doc.EpochTime, logdivider,
+		doc.TimeTaken, logdivider,
+		doc.Severity, logdivider,
+		doc.CallType, logdivider,
+		doc.CallTarget, logdivider,
+		doc.InFunc, logdivider,
+		doc.Msg, logdivider,
+		doc.Note,
+	)
+}
+
+// Close open file
+//
+func (l *simpleLogger) Close() {
+	l.filehandle.Close()
+}

--- a/server/instrumentation/log.go
+++ b/server/instrumentation/log.go
@@ -2,8 +2,8 @@ package instrumentation
 
 import (
 	"log"
-	"path/filepath"
 	"os"
+	"path/filepath"
 )
 
 const logdivider = "|"
@@ -11,7 +11,7 @@ const logdivider = "|"
 // The most trivial of implementations - write via vanilla log package.
 //
 type simpleLogger struct {
-	logger *log.Logger
+	logger     *log.Logger
 	filehandle *os.File
 }
 
@@ -45,7 +45,7 @@ func openFile(path string) (*os.File, error) {
 		}
 		fh = tmp
 	} else {
-		tmp, err := os.OpenFile(path, os.O_RDWR | os.O_CREATE | os.O_APPEND, 0666)
+		tmp, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
 		if err != nil {
 			return nil, err
 		}
@@ -69,7 +69,7 @@ func newFileLogger(settings *Settings) (MonitorOutput, error) {
 	}
 
 	return &simpleLogger{
-		logger: log.New(fh, "", log.LstdFlags),
+		logger:     log.New(fh, "", log.LstdFlags),
 		filehandle: fh,
 	}, nil
 }
@@ -77,7 +77,7 @@ func newFileLogger(settings *Settings) (MonitorOutput, error) {
 // Log event to file.
 //
 func (l *simpleLogger) Log(doc *event) {
-	l.logger.Println( logdivider,
+	l.logger.Println(logdivider,
 		doc.EpochTime, logdivider,
 		doc.TimeTaken, logdivider,
 		doc.Severity, logdivider,

--- a/server/instrumentation/monitor.go
+++ b/server/instrumentation/monitor.go
@@ -1,0 +1,184 @@
+package instrumentation
+
+import (
+	"errors"
+	"sync"
+	"net/http"
+	"fmt"
+	"io"
+	"encoding/json"
+)
+
+const (
+	// We'll only hold this many docs in memory (they're still written to logs ASAP)
+	MonitorMaxDocsHeld = 50
+
+	// Severity constants
+	severityError = "error"
+	severityWarn = "warning"
+	severityInfo = "info"
+)
+
+// Config for monitor's webserver
+//
+type WebserverConfig struct {
+	Port           int
+	EndpointHealth string
+}
+
+// Parent struct that handles writing to all child MonitorOutput(s)
+//
+type Monitor struct {
+	incoming chan *event
+
+	lock sync.Mutex
+	outputs []MonitorOutput // all available outputs
+	recent []*event // most recent docs
+	maxLen int  // max number of docs held internally
+	latest int  // last doc saved internally
+}
+
+// Create and return a new Monitor
+//  Kicks off child routine to write new log messages
+//
+func NewMonitor(outs ...MonitorOutput) (*Monitor, error) {
+	if len(outs) < 1 {
+		return nil, errors.New("Require at least one MonitorOutput to be configured")
+	}
+
+	m := &Monitor{
+		lock: sync.Mutex{},
+		outputs: outs,
+		maxLen: MonitorMaxDocsHeld,
+		recent: make([]*event, MonitorMaxDocsHeld),
+		incoming: make(chan *event),
+	}
+	return m, nil
+}
+
+// Pull down the Monitor & all outputs
+//
+func (m *Monitor) Stop() {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	close(m.incoming)
+	for _, out := range m.outputs {
+		out.Close()
+	}
+}
+
+// Build health / stats reply
+//
+func (m *Monitor) prepareReport() ([]byte, error) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	logs := []*event{}
+	for i := 0; i < m.maxLen; i++ {
+		index := (i + m.latest) % m.maxLen
+		if m.recent[index] == nil {
+			break
+		}
+		logs = append(logs, m.recent[index])
+	}
+
+	return json.Marshal(map[string]interface{}{
+		"logs": logs,
+		"status": "OK",
+	})
+}
+
+//
+//
+func (m *Monitor) healthCheck(w http.ResponseWriter, r *http.Request) {
+	logdata, err := m.prepareReport()
+	if err != nil {
+		w.WriteHeader(500)
+		io.WriteString(w, err.Error())
+		return
+	}
+
+	w.WriteHeader(200)
+	w.Write(logdata)
+}
+
+
+// Kick off the sub routines that run int the Monitor
+//  - routines to write to log(s)
+//  - routine to reply to http requests
+//
+func (m *Monitor) Start(settings *WebserverConfig) error {
+	go m.run() // handle incoming log messages
+	go m.run() // handle incoming log messages
+
+	go func(){ // serve up http endpoints
+		http.HandleFunc(settings.EndpointHealth, m.healthCheck)
+		err := http.ListenAndServe(fmt.Sprintf(":%d", settings.Port), nil)
+		if err != nil {
+			panic(err)
+		}
+	}()
+	return nil
+}
+
+// Intended to be run via a single routine - which listens forever for all incoming
+// docs and writes them to each available MonitorOutput mechanism.
+//
+func (m *Monitor) run() {
+	for doc := range m.incoming {
+		m.lock.Lock()
+		m.latest += 1 // Considered Atomic num, but I think we'd have to lock to apply math on next line anyhow?
+		m.latest %= m.maxLen
+		m.recent[m.latest] = doc
+		fmt.Println(m.recent)
+
+		m.lock.Unlock()
+
+		// ToDo: Do we need to lock here? I've tested this writing out 12+ logs w/ 20+ routines and it
+		// doesn't seem to break for me ..
+		for _, out := range m.outputs {
+			out.Log(doc)
+		}
+	}
+}
+
+// Write given doc to all output(s)
+// Since this is intended for logging, no errors due to being unable to log should cause failures.
+//
+func (m *Monitor) Log(msg string, opts ...Opt) {
+	event := newEvent(msg)
+
+	for _, o := range opts {
+		o(event)
+	}
+
+	m.incoming <- event
+}
+
+// Log a warning message
+//
+func (m *Monitor) Warn(msg string, opts ...Opt) {
+	event := newEvent(msg)
+
+	for _, o := range opts {
+		o(event)
+	}
+
+	event.Severity = severityWarn
+	m.incoming <- event
+}
+
+
+// Log an error message
+//
+func (m *Monitor) Err(err error, opts ...Opt) {
+	event := newEvent(err.Error())
+
+	for _, o := range opts {
+		o(event)
+	}
+
+	event.Severity = severityError
+	m.incoming <- event
+}

--- a/server/instrumentationLayer.go
+++ b/server/instrumentationLayer.go
@@ -1,0 +1,181 @@
+/*
+As the name 'shim' implies, ths layer sits between the bottom of the middleware and the server itself,
+it supplies no business logic at all (nor should it) - no attempt here is made to address errors or
+change data, it only logs traffic & events as they pass by.
+*/
+
+package main
+
+import (
+	wyc "github.com/voidshard/wysteria/common"
+	wsi "github.com/voidshard/wysteria/server/instrumentation"
+	"time"
+	"fmt"
+)
+
+type Shim struct {
+	server *WysteriaServer
+}
+
+// The server calls us to listen, we'll call the middleware server in turn.
+// Essentially, all we have to do is pass back and forth, and be sure not to change any state.
+//
+func (s *Shim) ListenAndServe(config string, server *WysteriaServer) error {
+	s.server = server
+	return server.middleware_server.ListenAndServe(config, s)
+}
+
+// Time is up, kill everything and shutdown the server, kill all connections
+//
+func (s *Shim) Shutdown() error {
+	s.server.Shutdown()
+	return nil
+}
+
+// Call on our monitor to do the actual logging business
+//
+func (s *Shim) log(err error, t int64, opts ...wsi.Opt) {
+	go func() {
+		opts = append(opts, wsi.Time(time.Now().UnixNano() - t))
+		if err != nil {
+			s.server.monitor.Err(err, opts...)
+			return
+		}
+		s.server.monitor.Log("", opts...)
+	}()
+}
+
+// All following funcs simply record the current time, call the appropriate server call
+// and pass the results back to the calling middleware.
+// Except of course, we log the call in the middle.
+//
+func (s *Shim) CreateCollection(in string) (string, error) {
+	ts := time.Now().UnixNano()
+	result, err := s.server.CreateCollection(in)
+	s.log(err, ts, wsi.IsCreate(), wsi.TargetCollection(), wsi.Note(in))
+	return result, err
+}
+
+func (s *Shim) CreateItem(in *wyc.Item) (string, error) {
+	ts := time.Now().UnixNano()
+	result, err := s.server.CreateItem(in)
+	note := fmt.Sprintf("%s %s %s", in.Parent, in.ItemType, in.Variant)
+	s.log(err, ts, wsi.IsCreate(), wsi.TargetItem(), wsi.Note(note))
+	return result, err
+}
+
+func (s *Shim) CreateVersion(in *wyc.Version) (string, int32, error) {
+	ts := time.Now().UnixNano()
+	resultId, resultVer, err := s.server.CreateVersion(in)
+	note := fmt.Sprintf("%s %s %d", in.Parent, resultId, resultVer)
+	s.log(err, ts, wsi.IsCreate(), wsi.TargetVersion(), wsi.Note(note))
+	return resultId, resultVer, err
+}
+
+func (s *Shim) CreateResource(in *wyc.Resource) (string, error) {
+	ts := time.Now().UnixNano()
+	result, err := s.server.CreateResource(in)
+	note := fmt.Sprintf("%s %s %s %s", in.Parent, in.Name, in.ResourceType, in.Location)
+	s.log(err, ts, wsi.IsCreate(), wsi.TargetResource(), wsi.Note(note))
+	return result, err
+}
+
+func (s *Shim) CreateLink(in *wyc.Link) (string, error) {
+	ts := time.Now().UnixNano()
+	result, err := s.server.CreateLink(in)
+	note := fmt.Sprintf("%s %s", in.Src, in.Dst)
+	s.log(err, ts, wsi.IsCreate(), wsi.TargetLink(), wsi.Note(note))
+	return result, err
+}
+
+func (s *Shim) DeleteCollection(in string) error {
+	ts := time.Now().UnixNano()
+	err := s.server.DeleteCollection(in)
+	s.log(err, ts, wsi.IsDelete(), wsi.TargetCollection(), wsi.Note(in))
+	return err
+}
+
+func (s *Shim) DeleteItem(in string) error {
+	ts := time.Now().UnixNano()
+	err := s.server.DeleteItem(in)
+	s.log(err, ts, wsi.IsDelete(), wsi.TargetItem(), wsi.Note(in))
+	return err	
+}
+
+func (s *Shim) DeleteVersion(in string) error {
+	ts := time.Now().UnixNano()
+	err := s.server.DeleteVersion(in)
+	s.log(err, ts, wsi.IsDelete(), wsi.TargetVersion(), wsi.Note(in))
+	return err
+}
+
+func (s *Shim) DeleteResource(in string) error {
+	ts := time.Now().UnixNano()
+	err := s.server.DeleteResource(in)
+	s.log(err, ts, wsi.IsDelete(), wsi.TargetResource(), wsi.Note(in))
+	return err
+}
+
+func (s *Shim) FindCollections(l int32, o int32, q []*wyc.QueryDesc) ([]*wyc.Collection, error) {
+	ts := time.Now().UnixNano()
+	results, err := s.server.FindCollections(l, o, q)
+	s.log(err, ts, wsi.IsFind(), wsi.TargetCollection(), wsi.Note(fmt.Sprintf("%d %d %d", l, o, len(q))))
+	return results, err
+}
+
+func (s *Shim) FindItems(l int32, o int32, q []*wyc.QueryDesc) ([]*wyc.Item, error) {
+	ts := time.Now().UnixNano()
+	results, err := s.server.FindItems(l, o, q)
+	s.log(err, ts, wsi.IsFind(), wsi.TargetItem(), wsi.Note(fmt.Sprintf("%d %d %d", l, o, len(q))))
+	return results, err
+}
+
+func (s *Shim) FindVersions(l int32, o int32, q []*wyc.QueryDesc) ([]*wyc.Version, error) {
+	ts := time.Now().UnixNano()
+	results, err := s.server.FindVersions(l, o, q)
+	s.log(err, ts, wsi.IsFind(), wsi.TargetVersion(), wsi.Note(fmt.Sprintf("%d %d %d", l, o, len(q))))
+	return results, err
+}
+
+func (s *Shim) FindResources(l int32, o int32, q []*wyc.QueryDesc) ([]*wyc.Resource, error) {
+	ts := time.Now().UnixNano()
+	results, err := s.server.FindResources(l, o, q)
+	s.log(err, ts, wsi.IsFind(), wsi.TargetResource(), wsi.Note(fmt.Sprintf("%d %d %d", l, o, len(q))))
+	return results, err
+}
+
+func (s *Shim) FindLinks(l int32, o int32, q []*wyc.QueryDesc) ([]*wyc.Link, error) {
+	ts := time.Now().UnixNano()
+	results, err := s.server.FindLinks(l, o, q)
+	s.log(err, ts, wsi.IsFind(), wsi.TargetLink(), wsi.Note(fmt.Sprintf("%d %d %d", l, o, len(q))))
+	return results, err
+}
+
+
+func (s *Shim) PublishedVersion(in string) (*wyc.Version, error) {
+	ts := time.Now().UnixNano()
+	result, err := s.server.PublishedVersion(in)
+	s.log(err, ts, wsi.IsPublished(), wsi.TargetVersion(), wsi.Note(in))
+	return result, err
+}
+
+func (s *Shim) SetPublishedVersion(in string) error {
+	ts := time.Now().UnixNano()
+	err := s.server.SetPublishedVersion(in)
+	s.log(err, ts, wsi.IsPublish(), wsi.TargetVersion(), wsi.Note(in))
+	return err
+}
+
+func (s *Shim) UpdateVersionFacets(in string, m map[string]string) error {
+	ts := time.Now().UnixNano()
+	err := s.server.UpdateVersionFacets(in, m)
+	s.log(err, ts, wsi.IsUpdate(), wsi.TargetVersion(), wsi.Note(in))
+	return err
+}
+
+func (s *Shim) UpdateItemFacets(in string, m map[string]string) error {
+	ts := time.Now().UnixNano()
+	err := s.server.UpdateItemFacets(in, m)
+	s.log(err, ts, wsi.IsUpdate(), wsi.TargetItem(), wsi.Note(in))
+	return err
+}

--- a/server/instrumentationLayer.go
+++ b/server/instrumentationLayer.go
@@ -7,10 +7,10 @@ change data, it only logs traffic & events as they pass by.
 package main
 
 import (
+	"fmt"
 	wyc "github.com/voidshard/wysteria/common"
 	wsi "github.com/voidshard/wysteria/server/instrumentation"
 	"time"
-	"fmt"
 )
 
 type Shim struct {
@@ -36,7 +36,7 @@ func (s *Shim) Shutdown() error {
 //
 func (s *Shim) log(err error, t int64, opts ...wsi.Opt) {
 	go func() {
-		opts = append(opts, wsi.Time(time.Now().UnixNano() - t))
+		opts = append(opts, wsi.Time(time.Now().UnixNano()-t))
 		if err != nil {
 			s.server.monitor.Err(err, opts...)
 			return
@@ -99,7 +99,7 @@ func (s *Shim) DeleteItem(in string) error {
 	ts := time.Now().UnixNano()
 	err := s.server.DeleteItem(in)
 	s.log(err, ts, wsi.IsDelete(), wsi.TargetItem(), wsi.Note(in))
-	return err	
+	return err
 }
 
 func (s *Shim) DeleteVersion(in string) error {
@@ -150,7 +150,6 @@ func (s *Shim) FindLinks(l int32, o int32, q []*wyc.QueryDesc) ([]*wyc.Link, err
 	s.log(err, ts, wsi.IsFind(), wsi.TargetLink(), wsi.Note(fmt.Sprintf("%d %d %d", l, o, len(q))))
 	return results, err
 }
-
 
 func (s *Shim) PublishedVersion(in string) (*wyc.Version, error) {
 	ts := time.Now().UnixNano()

--- a/server/wysteria-server.ini
+++ b/server/wysteria-server.ini
@@ -67,11 +67,20 @@
 
 [Database]
 Driver=bolt
-Database=wys_db
+Database=/tmp/wys_db
 
 [Searchbase]
 Driver=bleve
-Database=wys_sb
+Database=/tmp/wys_sb
 
 [Middleware]
-Driver="nats"
+Driver=nats
+
+[Health]
+Port=8150
+EndpointHealth=/health
+
+[Instrumentation "logfile"]
+Driver=logfile
+Location=test
+Target=wysteria.log

--- a/server/wysteria-server.ini
+++ b/server/wysteria-server.ini
@@ -82,5 +82,5 @@ EndpointHealth=/health
 
 [Instrumentation "logfile"]
 Driver=logfile
-Location=test
+Location=logs
 Target=wysteria.log

--- a/tools/stress/main.go
+++ b/tools/stress/main.go
@@ -7,10 +7,11 @@ We don't care to check for any errors here .. so SIGSEGVs can (and sometimes do)
 package main
 
 import (
-	wysteria "github.com/voidshard/wysteria/client"
-	"sync"
 	"fmt"
+	wysteria "github.com/voidshard/wysteria/client"
+	"log"
 	"math/rand"
+	"sync"
 )
 
 func spam(i, j int) {
@@ -21,11 +22,12 @@ func spam(i, j int) {
 
 	name := fmt.Sprintf("spam_%d_%d_%d", i, j, rand.Int())
 	col, _ := client.CreateCollection(name)
+	log.Println("[create] collection")
 
 	var last_item *wysteria.Item
 	var last_ver *wysteria.Version
 
-	for k := 0 ; k < 10; k ++ {
+	for k := 0; k < rand.Intn(15); k++ {
 		si := fmt.Sprintf("%d", i)
 		sj := fmt.Sprintf("%d", j)
 		sk := fmt.Sprintf("%d", k)
@@ -41,34 +43,65 @@ func spam(i, j int) {
 			fmt.Sprintf("var_%d_%d_%d", i, j, k),
 			m,
 		)
+		log.Println("[create] item")
 
 		if last_item != nil {
 			last_item.LinkTo(fmt.Sprintf("%d%d%d", i, j, k), item)
+			log.Println("[create] link")
 		}
 		last_item = item
 
-		for l := 0 ; l < 10; l ++ {
+		for x := 0; x < rand.Intn(20); x++ {
+			client.Search(wysteria.HasFacets(m)).FindItems(
+				wysteria.Limit(1+rand.Intn(10)*rand.Intn(10)),
+				wysteria.Offset(rand.Intn(10)),
+			)
+			log.Println("[search] item")
+		}
+
+		for l := 0; l < rand.Intn(10); l++ {
 			ver, _ := item.CreateVersion(m)
-			for p := 0 ; p < 5; p ++ {
+			log.Println("[create] version")
+			for p := 0; p < rand.Intn(5); p++ {
 				ver.AddResource(si, sj, sk)
+				log.Println("[create] resource")
 			}
+			ver.Publish()
+			log.Println("[publish] version")
 
 			if last_ver != nil {
 				last_ver.LinkTo(fmt.Sprintf("%d%d%d", i, j, k), last_ver)
+				log.Println("[create] link")
 			}
 			last_ver = ver
+
+			ver.Resources()
+			log.Println("[find] resource")
+			ver.Linked()
+			log.Println("[find] link")
+		}
+
+		last_item.PublishedVersion()
+		log.Println("[published] version")
+
+		for y := 0; y < rand.Intn(20); y++ {
+			client.Search(wysteria.HasFacets(m)).FindVersions(
+				wysteria.Limit(1+rand.Intn(10)*rand.Intn(10)),
+				wysteria.Offset(rand.Intn(10)),
+			)
+			log.Println("[find] version")
 		}
 	}
 }
 
-func main () {
+func main() {
 	wg := sync.WaitGroup{}
 
-	for i := 0 ; i < 10; i ++ {
+	for i := 0; i < 10; i++ {
 		wg.Add(1)
 		go func() {
 			closed_i := i
-			for j := 0 ; j < 10; j ++ {
+			for j := 0; j < 10000; j++ {
 				spam(closed_i, j)
 			}
 			wg.Done()

--- a/tools/stress/main.go
+++ b/tools/stress/main.go
@@ -1,0 +1,79 @@
+/*
+Simple tool to simply throw requests at wysteria by the ton.
+
+We don't care to check for any errors here .. so SIGSEGVs can (and sometimes do) occur. Meh.
+*/
+
+package main
+
+import (
+	wysteria "github.com/voidshard/wysteria/client"
+	"sync"
+	"fmt"
+	"math/rand"
+)
+
+func spam(i, j int) {
+	client, err := wysteria.New()
+	if err != nil {
+		panic(err) // one err we will check -- we kinda need the client
+	}
+
+	name := fmt.Sprintf("spam_%d_%d_%d", i, j, rand.Int())
+	col, _ := client.CreateCollection(name)
+
+	var last_item *wysteria.Item
+	var last_ver *wysteria.Version
+
+	for k := 0 ; k < 10; k ++ {
+		si := fmt.Sprintf("%d", i)
+		sj := fmt.Sprintf("%d", j)
+		sk := fmt.Sprintf("%d", k)
+
+		m := map[string]string{
+			"i": si,
+			"j": sj,
+			"k": sk,
+		}
+
+		item, _ := col.CreateItem(
+			fmt.Sprintf("item_%d_%d_%d", i, j, k),
+			fmt.Sprintf("var_%d_%d_%d", i, j, k),
+			m,
+		)
+
+		if last_item != nil {
+			last_item.LinkTo(fmt.Sprintf("%d%d%d", i, j, k), item)
+		}
+		last_item = item
+
+		for l := 0 ; l < 10; l ++ {
+			ver, _ := item.CreateVersion(m)
+			for p := 0 ; p < 5; p ++ {
+				ver.AddResource(si, sj, sk)
+			}
+
+			if last_ver != nil {
+				last_ver.LinkTo(fmt.Sprintf("%d%d%d", i, j, k), last_ver)
+			}
+			last_ver = ver
+		}
+	}
+}
+
+func main () {
+	wg := sync.WaitGroup{}
+
+	for i := 0 ; i < 10; i ++ {
+		wg.Add(1)
+		go func() {
+			closed_i := i
+			for j := 0 ; j < 10; j ++ {
+				spam(closed_i, j)
+			}
+			wg.Done()
+		}()
+	}
+
+	wg.Wait()
+}


### PR DESCRIPTION
Unsure about the approach - seems a nice division of concerns and better than filling the actual server calls with logging. It does give a pretty good view of what is happening internally .. but we can't see stuff in the middleware layer. 

About to test the Elastic handler now so possible fixes incoming. 

Sample log output contains errors, function call details, time, epoch time & time taken (nano seconds)
```
2017/07/16 09:53:48 | 1500155628 | 262397 | info | create | collection |  |  | spam_10_0
2017/07/16 09:53:48 | 1500155628 | 213519 | error | create | collection |  | Unable to create: Would cause duplicate Collect
ion | spam_10_0
2017/07/16 09:53:48 | 1500155628 | 226475 | error | create | collection |  | Unable to create: Would cause duplicate Collect
ion | spam_10_0
2017/07/16 09:56:21 | 1500155781 | 254367 | info | create | collection |  |  | spam_10_0_8888486765101048019
2017/07/16 09:56:21 | 1500155781 | 203393 | info | create | collection |  |  | spam_10_0_582801518877924247
2017/07/16 09:56:21 | 1500155781 | 345467 | info | create | collection |  |  | spam_10_0_8527555209696361223
2017/07/16 09:56:21 | 1500155781 | 413956 | info | create | collection |  |  | spam_10_0_5678536936800366009
2017/07/16 09:56:21 | 1500155781 | 507217 | info | create | collection |  |  | spam_10_0_7802679599446896000
2017/07/16 09:56:21 | 1500155781 | 630520 | info | create | collection |  |  | spam_10_0_1545539202771121103
2017/07/16 09:56:21 | 1500155781 | 763547 | info | create | collection |  |  | spam_7_0_5070265533636780347
2017/07/16 09:56:21 | 1500155781 | 873021 | info | create | collection |  |  | spam_10_0_3565035678607031169
2017/07/16 09:56:21 | 1500155781 | 431908 | info | create | item |  |  | 596a8f85e138230c35474961 item_10_0_0 var_10_0_0
2017/07/16 09:56:21 | 1500155781 | 1065760 | info | create | collection |  |  | spam_10_0_5323959010254660924
2017/07/16 09:56:21 | 1500155781 | 428535 | info | create | item |  |  | 596a8f85e138230c35474966 item_10_0_0 var_10_0_0
```

Also, the gcfg config reader is pretty cool. Using this you can set up multiple outputs at once -
```
[Instrumentation "a"]
Driver=logfile
Location=test
Target=a.log

[Instrumentation "b"]
Driver=logfile
Location=test
Target=b.log
```
.. etc 

Sample json from the http endpoint
```
{
"logs": [
{
"Msg": "",
"Note": "596a8ffee138230c354a1feb 10 9 9",
"InFunc": "",
"Severity": "info",
"EpochTime": 1500155902,
"UTCTime": "2017-07-15 21:58:22.290378562 +0000 UTC",
"TimeTaken": 434424,
"CallType": "create",
"CallTarget": "resource"
}, ...],
 "status": "OK"
}
```

Could add some basic stats about read/writes, calls per time slice ..something .. also the OK is hard coded atm .. probably should scream murder if something is wrong.