### PR TITLE
Impr/allow empty search for collections

### DIFF
--- a/client/examples/03/main.go
+++ b/client/examples/03/main.go
@@ -69,4 +69,36 @@ func main() {
 	//--tree/oak or tree/elm items--
 	//tree oak
 	//tree elm
+
+	// We can also search without any search terms.
+	//  Note that internally Wysteria will cap searches that include no query args
+	fmt.Println("\n--collections--")
+	collections, _ := client.Search().FindCollections()
+	for _, c := range collections {
+		fmt.Println(c.Name())
+	}
+
+	fmt.Println("--items--")
+	items, _ = client.Search().FindItems()
+	for _, i := range items {
+		fmt.Println(i.Type(), i.Variant())
+	}
+
+	fmt.Println("--versions--")
+	versions, _ := client.Search().FindVersions()
+	for _, v := range versions {
+		fmt.Println(v.Version())
+	}
+
+	fmt.Println("--resources--")
+	resources, _ = client.Search().FindResources()
+	for _, r := range resources {
+		fmt.Println(r.Name(), r.Type(), r.Name())
+	}
+
+	fmt.Println("--links--")
+	links, _ := client.Search().FindLinks()
+	for _, l := range links {
+		fmt.Println(l.Name(), l.SourceId(), l.DestinationId())
+	}
 }

--- a/client/search.go
+++ b/client/search.go
@@ -1,7 +1,6 @@
 package wysteria_client
 
 import (
-	"errors"
 	wyc "github.com/voidshard/wysteria/common"
 )
 
@@ -155,11 +154,7 @@ func ResourceLocation(s string) SearchParam {
 
 // Find all matching Collections given our search params
 func (i *Search) FindCollections(opts ...SearchOption) ([]*Collection, error) {
-	if i.nextQValid {
-		i.query = append(i.query, i.nextQuery)
-		i.nextQValid = false
-		i.nextQuery = newQuery()
-	}
+	i.ready()
 
 	for _, option := range opts {
 		option(i)
@@ -182,10 +177,7 @@ func (i *Search) FindCollections(opts ...SearchOption) ([]*Collection, error) {
 
 // Find all matching Items given our search params
 func (i *Search) FindItems(opts ...SearchOption) ([]*Item, error) {
-	err := i.ready()
-	if err != nil {
-		return nil, err
-	}
+	i.ready()
 
 	for _, option := range opts {
 		option(i)
@@ -208,10 +200,7 @@ func (i *Search) FindItems(opts ...SearchOption) ([]*Item, error) {
 
 // Find all matching Versions given our search params
 func (i *Search) FindVersions(opts ...SearchOption) ([]*Version, error) {
-	err := i.ready()
-	if err != nil {
-		return nil, err
-	}
+	i.ready()
 
 	for _, option := range opts {
 		option(i)
@@ -234,10 +223,7 @@ func (i *Search) FindVersions(opts ...SearchOption) ([]*Version, error) {
 
 // Find all matching Resources given our search params
 func (i *Search) FindResources(opts ...SearchOption) ([]*Resource, error) {
-	err := i.ready()
-	if err != nil {
-		return nil, err
-	}
+	i.ready()
 
 	for _, option := range opts {
 		option(i)
@@ -260,25 +246,17 @@ func (i *Search) FindResources(opts ...SearchOption) ([]*Resource, error) {
 
 // Ready the current query description object if it is valid.
 // If we have been given nothing to search for, error
-func (i *Search) ready() error {
+func (i *Search) ready() {
 	if i.nextQValid {
 		i.query = append(i.query, i.nextQuery)
 		i.nextQValid = false
 		i.nextQuery = newQuery()
 	}
-
-	if len(i.query) < 1 {
-		return errors.New("You must specify at least one query term.")
-	}
-	return nil
 }
 
 // Find all matching Links given our search params
 func (i *Search) FindLinks(opts ...SearchOption) ([]*Link, error) {
-	err := i.ready()
-	if err != nil {
-		return nil, err
-	}
+	i.ready()
 
 	for _, option := range opts {
 		option(i)

--- a/server/searchbase/bleve.go
+++ b/server/searchbase/bleve.go
@@ -305,6 +305,21 @@ func genericQuery(limit, from int, index bleve.Index, convert func(desc *wyc.Que
 
 // Search for collections matching the given query descriptions
 func (b *bleveSearchbase) QueryCollection(limit, from int, query ...*wyc.QueryDesc) ([]string, error) {
+	if len(query) == 0 {
+		search_query := bleve.NewQueryStringQuery("*")
+		search := bleve.NewSearchRequestOptions(search_query, limit, from, false)
+		result, err := b.collections.Search(search)
+
+		if err != nil || result.Hits.Len() == 0 {
+			return nil, err
+		}
+
+		ids := []string{}
+		for _, doc := range result.Hits {
+			ids = append(ids, doc.ID)
+		}
+		return ids, nil
+	}
 	return genericQuery(limit, from, b.collections, toCollectionQueryString, query...)
 }
 

--- a/server/searchbase/elastic.go
+++ b/server/searchbase/elastic.go
@@ -132,51 +132,71 @@ func (e *elasticSearch) DeleteLink(ids ...string) error {
 	return e.generic_delete(tableLink, ids...)
 }
 
+// Special case for a query that has no query args (match all query)
+func (e *elasticSearch) emptyQuery(limit, from int, table string) ([]string, error) {
+	base := e.client.Search().Index(e.Settings.Database).Type(table).Fields("Id").From(from)
+	if limit > matchAllSearchLimit {
+		limit = matchAllSearchLimit
+	}
+	if limit > 0 {
+		base.Size(limit)
+	}
+
+	matchAll := elastic.NewBoolQuery().Must(elastic.NewMatchAllQuery())
+	results := []string{}
+
+	res, err := base.Query(matchAll).Do()  // perform the query
+	if err != nil {
+		return results, err
+	} else {
+		// And pull together all the results
+		for _, hit := range res.Hits.Hits {
+			// ToDo: works, but could use some straightening up
+			// (We only asked for the Id field)
+			result_id := hit.Fields["Id"].([]interface{})[0].(string)
+			results = append(results, result_id)
+		}
+	}
+	return results, nil
+}
+
 // Search for collections matching the given query descriptions
 func (e *elasticSearch) QueryCollection(limit, from int, qs ...*wyc.QueryDesc) ([]string, error) {
 	if len(qs) == 0 {
-		base := e.client.Search().Index(e.Settings.Database).Type(tableCollection).Fields("Id").From(from)
-		if limit > 0 {
-			base.Size(limit)
-		}
-
-		matchAll := elastic.NewBoolQuery().Must(elastic.NewMatchAllQuery())
-		results := []string{}
-
-		res, err := base.Query(matchAll).Do()  // perform the query
-		if err != nil {
-			return results, err
-		} else {
-			// And pull together all the results
-			for _, hit := range res.Hits.Hits {
-				// ToDo: works, but could use some straightening up
-				// (We only asked for the Id field)
-				result_id := hit.Fields["Id"].([]interface{})[0].(string)
-				results = append(results, result_id)
-			}
-		}
-		return results, nil
+		return e.emptyQuery(limit, from, tableCollection)
 	}
 	return e.fanSearch(tableCollection, elasticTermsCollection, limit, from, qs...)
 }
 
 // Search for items matching the given query descriptions
 func (e *elasticSearch) QueryItem(limit, from int, qs ...*wyc.QueryDesc) ([]string, error) {
+	if len(qs) == 0 {
+		return e.emptyQuery(limit, from, tableItem)
+	}
 	return e.fanSearch(tableItem, elasticTermsItem, limit, from, qs...)
 }
 
 // Search for versions matching the given query descriptions
 func (e *elasticSearch) QueryVersion(limit, from int, qs ...*wyc.QueryDesc) ([]string, error) {
+	if len(qs) == 0 {
+		return e.emptyQuery(limit, from, tableVersion)
+	}
 	return e.fanSearch(tableVersion, elasticTermsVersion, limit, from, qs...)
 }
 
 // Search for resources matching the given query descriptions
 func (e *elasticSearch) QueryResource(limit, from int, qs ...*wyc.QueryDesc) ([]string, error) {
+	if len(qs) == 0 {
+		return e.emptyQuery(limit, from, tableResource)
+	}
 	return e.fanSearch(tableResource, elasticTermsResource, limit, from, qs...)
 }
 
 // Search for links matching the given query descriptions
 func (e *elasticSearch) QueryLink(limit, from int, qs ...*wyc.QueryDesc) ([]string, error) {
+	if len(qs) == 0 {
+		return e.emptyQuery(limit, from, tableLink)
+	}
 	return e.fanSearch(tableLink, elasticTermsLink, limit, from, qs...)
 }
 

--- a/server/searchbase/elastic.go
+++ b/server/searchbase/elastic.go
@@ -145,7 +145,7 @@ func (e *elasticSearch) emptyQuery(limit, from int, table string) ([]string, err
 	matchAll := elastic.NewBoolQuery().Must(elastic.NewMatchAllQuery())
 	results := []string{}
 
-	res, err := base.Query(matchAll).Do()  // perform the query
+	res, err := base.Query(matchAll).Do() // perform the query
 	if err != nil {
 		return results, err
 	} else {

--- a/server/searchbase/searchbase.go
+++ b/server/searchbase/searchbase.go
@@ -22,6 +22,9 @@ import (
 )
 
 const (
+	// The most results we'll ever return in one page if no query args are given
+	matchAllSearchLimit = 10000
+
 	// Driver name strings
 	DriverElastic = "elastic"
 	DriverBleve   = "bleve"


### PR DESCRIPTION
Allow termless searches. I've extended the original from allowing only collections to be returned without search params to everything. But I've also capped the number of results returned from such queries with a const.