### PR TITLE
No search for id query

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -10,6 +10,8 @@ package wysteria_client
 import (
 	wyc "github.com/voidshard/wysteria/common"
 	wcm "github.com/voidshard/wysteria/common/middleware"
+	"fmt"
+	"errors"
 )
 
 const (
@@ -74,6 +76,32 @@ func New(opts ...ClientOption) (*Client, error) {
 	}
 	client.middleware = middleware
 	return client, middleware.Connect(&client.settings.Middleware)
+}
+
+// Collection is a helpful wrapper that looks for a single collection
+// with either the name or Id of the given 'identifier' and returns it if found
+func (w *Client) Collection(identifier string) (*Collection, error) {
+	results, err := w.Search(Id(identifier)).Or(Name(identifier)).FindCollections(Limit(1))
+	if err != nil {
+		return nil, err
+	}
+
+	if len(results) == 1 {
+		return results[0], nil
+	}
+	return nil, errors.New(fmt.Sprintf("Expected 1 result, got %d", len(results)))
+}
+
+// Item is a helpful wrapper that looks up an Item by ID and returns it (if found).
+func (w *Client) Item(in string) (*Item, error) {
+	results, err := w.Search(Id(in)).FindItems(Limit(1))
+	if err != nil {
+		return nil, err
+	}
+	if len(results) == 1 {
+		return results[0], nil
+	}
+	return nil, errors.New(fmt.Sprintf("Expected 1 result, got %d", len(results)))
 }
 
 // Close any open server connection(s)

--- a/client/collection.go
+++ b/client/collection.go
@@ -1,8 +1,6 @@
 package wysteria_client
 
 import (
-	"errors"
-	"fmt"
 	wyc "github.com/voidshard/wysteria/common"
 )
 
@@ -23,8 +21,13 @@ func (c *Collection) Id() string {
 }
 
 // Return the Id of this collection's parent (if any)
-func (c *Collection) Parent() string {
+func (c *Collection) ParentId() string {
 	return c.data.Parent
+}
+
+// Return the parent collection of this collection (if any)
+func (c *Collection) Parent() (*Collection, error) {
+	return c.conn.Collection(c.ParentId())
 }
 
 // Get the facet value and a bool indicating if the value exists for the given key.
@@ -127,20 +130,6 @@ func (w *Client) createCollection(name string, parent *Collection, opts ...Creat
 //  - The collection name is required to be unique among all collections
 func (w *Client) CreateCollection(name string, opts ...CreateOption) (*Collection, error) {
 	return w.createCollection(name,  nil, opts...)
-}
-
-// Collection is a helpful wrapper that looks for a single collection
-// with either the name or Id of the given 'identifier' and returns it if found
-func (w *Client) Collection(identifier string) (*Collection, error) {
-	results, err := w.Search(Id(identifier)).Or(Name(identifier)).FindCollections()
-	if err != nil {
-		return nil, err
-	}
-
-	if len(results) == 1 {
-		return results[0], nil
-	}
-	return nil, errors.New(fmt.Sprintf("Expected 1 result, got %d", len(results)))
 }
 
 // Set initial user defined facets

--- a/client/examples/12/main.go
+++ b/client/examples/12/main.go
@@ -25,11 +25,14 @@ func main() {
 	}
 
 	fmt.Println(projectCollection.Id(), projectCollection.Name())
-	fmt.Println(mapsOfFoo.Name(), "child of", mapsOfFoo.Parent())
+	fmt.Println(mapsOfFoo.Name(), "child of", mapsOfFoo.ParentId())
 
 	// Two collections with the same parent still may not have the same name
 	_, err = projectCollection.CreateCollection("maps")
 	if err == nil {
 		panic("We shouldn't be able to get here!")
 	}
+
+	project, _ := mapsOfFoo.Parent()
+	fmt.Println("Found my parent", project.Name())
 }

--- a/server/config_test.go
+++ b/server/config_test.go
@@ -14,15 +14,12 @@ func TestGetDefaults(t *testing.T) {
 	}{
 		// Required minimum value(s) in order to connect and operate
 		{"Middleware Driver", settings.Middleware.Driver},
-		{"Middleware Host", settings.Middleware.Config},
 
 		{"Database Driver", settings.Database.Driver},
-		{"Database Host", settings.Database.Host},
 		{"Database Port", strconv.Itoa(settings.Database.Port)},
 		{"Database Database", settings.Database.Database},
 
 		{"Searchbase Driver", settings.Searchbase.Driver},
-		{"Searchbase Host", settings.Searchbase.Host},
 		{"Searchbase Port", strconv.Itoa(settings.Searchbase.Port)},
 		{"Searchbase Database", settings.Searchbase.Database},
 	}

--- a/server/instrumentation/instrumentation.go
+++ b/server/instrumentation/instrumentation.go
@@ -23,6 +23,7 @@ const (
 	// The driver names that we accept
 	DriverLogfile = "logfile"
 	DriverElastic = "elastic"
+	DriverStdout  = "stdout"
 
 	// Call types
 	callFind      = "find"
@@ -45,6 +46,7 @@ var (
 	connectors = map[string]func(*Settings) (MonitorOutput, error){
 		DriverLogfile: newFileLogger,
 		DriverElastic: newElasticLogger,
+		DriverStdout:  newStdoutLogger,
 	}
 )
 

--- a/server/instrumentation/stdout.go
+++ b/server/instrumentation/stdout.go
@@ -1,0 +1,31 @@
+package instrumentation
+
+import (
+	"log"
+)
+
+
+func newStdoutLogger(s *Settings) (MonitorOutput, error) {
+	return &stdoutLogger{}, nil
+}
+
+type stdoutLogger struct {}
+
+// Log event to shell
+//
+func (l *stdoutLogger) Log(doc *event) {
+	log.Println(logdivider,
+		doc.EpochTime, logdivider,
+		doc.TimeTaken, logdivider,
+		doc.Severity, logdivider,
+		doc.CallType, logdivider,
+		doc.CallTarget, logdivider,
+		doc.InFunc, logdivider,
+		doc.Msg, logdivider,
+		doc.Note,
+	)
+}
+
+// Close open file
+//
+func (l *stdoutLogger) Close() {}

--- a/server/main.go
+++ b/server/main.go
@@ -1,16 +1,31 @@
 package main
 
 import (
+	"os"
 	"time"
+	kp "gopkg.in/alecthomas/kingpin.v2"
+	wsi "github.com/voidshard/wysteria/server/instrumentation"
 )
 
 func main() {
+	app := kp.New("Wysteria", "Asset management system")
+	verbose := app.Flag("verbose", "Log server output to shell").Short('v').Bool()
+	config := app.Flag("config", "Explicitly set a config file").Short('c').String()
+	graceful := app.Flag("shutdown", "Time allotted for graceful shutdown").Default("3s").Duration()
+	kp.MustParse(app.Parse(os.Args[1:]))
+
+	cfg := loadConfig(*config)
+
+	if *verbose {
+		cfg.Instrumentation["wys_verbose"] = &wsi.Settings{Driver: wsi.DriverStdout}
+	}
+
 	server := WysteriaServer{
 		// Allocate 3 seconds for the server connections to be severed when shutting down
-		GracefulShutdownTime: time.Second * 3,
+		GracefulShutdownTime: *graceful * time.Second,
 
 		// Pass in all config settings
-		settings: Config,
+		settings: cfg,
 	}
 
 	// Connect to all required endpoints, die in the event of any failures

--- a/server/server.go
+++ b/server/server.go
@@ -501,10 +501,15 @@ func (s *WysteriaServer) FindCollections(limit, offset int32, qs []*wyc.QueryDes
 		return nil, err
 	}
 
-	ids, err := s.searchbase.QueryCollection(int(limit), int(offset), qs...)
-	if err != nil {
-		return nil, err
+	ids, queries := ExtractIdQueries(qs)
+	if len(queries) > 0 || len(ids) == 0 {
+		found, err := s.searchbase.QueryCollection(int(limit), int(offset), queries...)
+		if err != nil {
+			return nil, err
+		}
+		ids = append(ids, found...)
 	}
+
 	if len(ids) < 1 {
 		return []*wyc.Collection{}, nil
 	}
@@ -518,10 +523,15 @@ func (s *WysteriaServer) FindItems(limit, offset int32, qs []*wyc.QueryDesc) ([]
 		return nil, err
 	}
 
-	ids, err := s.searchbase.QueryItem(int(limit), int(offset), qs...)
-	if err != nil {
-		return nil, err
+	ids, queries := ExtractIdQueries(qs)
+	if len(queries) > 0 || len(ids) == 0 {
+		found, err := s.searchbase.QueryItem(int(limit), int(offset), queries...)
+		if err != nil {
+			return nil, err
+		}
+		ids = append(ids, found...)
 	}
+
 	if len(ids) < 1 {
 		return []*wyc.Item{}, nil
 	}
@@ -535,10 +545,15 @@ func (s *WysteriaServer) FindVersions(limit, offset int32, qs []*wyc.QueryDesc) 
 		return nil, err
 	}
 
-	ids, err := s.searchbase.QueryVersion(int(limit), int(offset), qs...)
-	if err != nil {
-		return nil, err
+	ids, queries := ExtractIdQueries(qs)
+	if len(queries) > 0 || len(ids) == 0 {
+		found, err := s.searchbase.QueryVersion(int(limit), int(offset), queries...)
+		if err != nil {
+			return nil, err
+		}
+		ids = append(ids, found...)
 	}
+
 	if len(ids) < 1 {
 		return []*wyc.Version{}, nil
 	}
@@ -552,10 +567,15 @@ func (s *WysteriaServer) FindResources(limit, offset int32, qs []*wyc.QueryDesc)
 		return nil, err
 	}
 
-	ids, err := s.searchbase.QueryResource(int(limit), int(offset), qs...)
-	if err != nil {
-		return nil, err
+	ids, queries := ExtractIdQueries(qs)
+	if len(queries) > 0 || len(ids) == 0 {
+		found, err := s.searchbase.QueryResource(int(limit), int(offset), queries...)
+		if err != nil {
+			return nil, err
+		}
+		ids = append(ids, found...)
 	}
+
 	if len(ids) < 1 {
 		return []*wyc.Resource{}, nil
 	}
@@ -569,10 +589,15 @@ func (s *WysteriaServer) FindLinks(limit, offset int32, qs []*wyc.QueryDesc) ([]
 		return nil, err
 	}
 
-	ids, err := s.searchbase.QueryLink(int(limit), int(offset), qs...)
-	if err != nil {
-		return nil, err
+	ids, queries := ExtractIdQueries(qs)
+	if len(queries) > 0 || len(ids) == 0 {
+		found, err := s.searchbase.QueryLink(int(limit), int(offset), queries...)
+		if err != nil {
+			return nil, err
+		}
+		ids = append(ids, found...)
 	}
+
 	if len(ids) < 1 {
 		return []*wyc.Link{}, nil
 	}

--- a/server/utils.go
+++ b/server/utils.go
@@ -1,6 +1,9 @@
 package main
 
-import "gopkg.in/mgo.v2/bson"
+import (
+	"gopkg.in/mgo.v2/bson"
+	wyc "github.com/voidshard/wysteria/common"
+)
 
 // Create a new ID string at random
 func NewId() string {
@@ -15,4 +18,41 @@ func ListContains(key string, values []string) bool {
 		}
 	}
 	return false
+}
+
+// Divide the search queries into a list of results to get by ID and a list of queries we need to run
+//
+func ExtractIdQueries(qs []*wyc.QueryDesc) ([]string, []*wyc.QueryDesc) {
+	ids := []string{}
+	queries := []*wyc.QueryDesc{}
+
+	for _, q := range qs {
+		if IsIdOnlyQuery(q) {
+			ids = append(ids, q.Id)
+		} else {
+			queries = append(queries, q)
+		}
+	}
+
+	return ids, queries
+}
+
+// Checks if ID is the *only* field the user is searching for. If so, we can simply get it from the DB.
+//
+func IsIdOnlyQuery(q *wyc.QueryDesc) bool {
+	if q.Id == "" { // no id is set, so it can't be an id only query
+		return false
+	}
+	if q.Facets != nil {
+		return false
+	}
+	if q.VersionNumber > 0 {
+		return false
+	}
+	for _, s := range []string{q.Parent, q.ItemType, q.Variant, q.Name, q.ResourceType, q.Location, q.LinkSrc, q.LinkDst} {
+		if s != "" {
+			return false
+		}
+	}
+	return true
 }


### PR DESCRIPTION
This is the updated server side code I've been using in a develop branch for a while, the main change here is that if you search for something by ID we now extract those IDs and simply grab them from the database directly, rather than actually search for them. 

This means you should be able to search for something pretty much immediately after creating it provided you're searching by ID. (This doesn't change the 'no immediate search' caveat around searches using fields other than ID, the database interface is only set up to retrieve by ID).

Because it was immensely helpful I also added another logger - to std out - and added a -v server flag so you can have wysteria print out what's happening as it happens. Looks something like -
```
./wys -v               
2017/10/07 14:05:44 WARNING: No config found, using OS temporary folders for storage.
2017/10/07 14:05:44 Initializing monitoring ...
2017/10/07 14:05:44 Opening database bolt :0
2017/10/07 14:05:44 Opening searchbase bleve :0
2017/10/07 14:05:44 Initializing middleware nats
2017/10/07 14:05:44 Spinning up middleware & waiting for connections
2017/10/07 14:06:23 | 1507381583000 | 192634355 | info | create | collection |  |  | tiles
2017/10/07 14:06:23 | 1507381583000 | 18690112 | info | update | item |  |  | 59d8d14f5e370e24d678385b
2017/10/07 14:06:23 | 1507381583000 | 787012 | info | create | item |  |  | 59d8d14f5e370e24d678385b tree oak
2017/10/07 14:06:23 | 1507381583000 | 1019982 | info | create | version |  |  | 59d8d14f5e370e24d678385c 59d8d14f5e370e24d678385d 1
2017/10/07 14:06:23 | 1507381583000 | 444560 | info | create | resource |  |  | 59d8d14f5e370e24d678385d default png url://images/oak01.png
2017/10/07 14:06:23 | 1507381583000 | 308232 | info | create | resource |  |  | 59d8d14f5e370e24d678385d stats xml /path/to/file.xml
2017/10/07 14:06:23 | 1507381583000 | 365870 | info | create | item |  |  | 59d8d14f5e370e24d678385b tree elm
2017/10/07 14:06:23 | 1507381583000 | 491422 | info | create | version |  |  | 59d8d14f5e370e24d6783860 59d8d14f5e370e24d6783861 1
2017/10/07 14:06:23 | 1507381583000 | 428873 | info | create | resource |  |  | 59d8d14f5e370e24d6783861 default png /path/to/elm01.png
2017/10/07 14:06:23 | 1507381583000 | 353860 | info | create | resource |  |  | 59d8d14f5e370e24d6783861 lowres jpeg /path/lowres/image.jpeg
2017/10/07 14:06:23 | 1507381583000 | 481239 | info | create | item |  |  | 59d8d14f5e370e24d678385b tree pine
2017/10/07 14:06:23 | 1507381583000 | 843348 | info | create | version |  |  | 59d8d14f5e370e24d6783864 59d8d14f5e370e24d6783865 1
2017/10/07 14:06:23 | 1507381583000 | 446510 | info | create | resource |  |  | 59d8d14f5e370e24d6783865 default png /path/to/pine01.png
2017/10/07 14:06:23 | 1507381583000 | 495778 | info | create | resource |  |  | 59d8d14f5e370e24d6783865 lowres jpeg /path/lowres/image.jpeg
2017/10/07 14:06:23 | 1507381583000 | 649502 | info | create | resource |  |  | 59d8d14f5e370e24d6783865 stats json url://file.json
2017/10/07 14:06:23 | 1507381583000 | 662807 | info | create | version |  |  | 59d8d14f5e370e24d678385c 59d8d14f5e370e24d6783869 2
2017/10/07 14:06:23 | 1507381583000 | 628403 | info | create | resource |  |  | 59d8d14f5e370e24d6783869 default png /other/images/oak02.png
2017/10/07 14:06:23 | 1507381583000 | 98213 | info | publish | version |  |  | 59d8d14f5e370e24d6783869
2017/10/07 14:06:23 | 1507381583000 | 82744 | info | publish | version |  |  | 59d8d14f5e370e24d6783861
2017/10/07 14:06:23 | 1507381583000 | 71663 | info | publish | version |  |  | 59d8d14f5e370e24d6783865
2017/10/07 14:06:23 | 1507381583000 | 852933 | info | create | version |  |  | 59d8d14f5e370e24d678385c 59d8d14f5e370e24d678386b 3
2017/10/07 14:06:23 | 1507381583000 | 336521 | info | create | resource |  |  | 59d8d14f5e370e24d678386b default png /other/images/oak03.png
2017/10/07 14:06:23 | 1507381583000 | 304663 | info | create | collection |  |  | maps
2017/10/07 14:06:23 | 1507381583000 | 276931 | info | update | item |  |  | 59d8d14f5e370e24d678386d
2017/10/07 14:06:23 | 1507381583000 | 600188 | info | create | item |  |  | 59d8d14f5e370e24d678386d map forest
```

It probably should be it's own branch & pull req but .. I'm lazy .. 